### PR TITLE
Fix: Address final TypeScript error in negotiation page

### DIFF
--- a/app/negotiation/page.tsx
+++ b/app/negotiation/page.tsx
@@ -182,7 +182,8 @@ function NegotiationContent() {
     setSellerEmotion(option.emotion);
 
     if (option.unlocks) {
-      setAvailableQuestions(prev => [...prev, ...option.unlocks.filter(id => !askedQuestions.has(id))]);
+      const unlocks = option.unlocks;
+      setAvailableQuestions(prev => [...prev, ...unlocks.filter(id => !askedQuestions.has(id))]);
     }
 
     if (questionId === 'creative_solution_intro') {


### PR DESCRIPTION
This commit fixes the final TypeScript error that was causing the Vercel build to fail. The error was in `app/negotiation/page.tsx`, where `option.unlocks` was possibly undefined.

This commit also includes all the previous changes that introduced a global state management solution using Zustand, refactored the application to use it, and fixed all other ESLint errors and warnings.

Key changes:
- Fixed the TypeScript error in `app/negotiation/page.tsx` by ensuring `option.unlocks` is defined before use.
- Fixed all `react/no-unescaped-entities` errors by properly escaping special characters in the JSX.
- Removed all unused variables to fix the `@typescript-eslint/no-unused-vars` warnings.
- Restructured the code in `app/negotiation/page.tsx` to fix the `react-hooks/rules-of-hooks` error.
- Added the missing dependencies to the `useEffect` hooks to resolve the `react-hooks/exhaustive-deps` warnings.
- Introduced a global state management solution using Zustand.
- Added the `eslint` dependency.